### PR TITLE
docs(integrations): simplify `zsh4humans` installation method

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -41,7 +41,7 @@ Another option that doesn't use git is to install the required dependency manual
 z4h install olets/zsh-job-queue || return # Dependency for olets/zsh-abbr.
 z4h install olets/zsh-abbr || return
 zstyle :z4h:olets/zsh-abbr postinstall \
-  'rm -rf $Z4H_PACKAGE_DIR/zsh-job-queue; ln -s ${Z4H_UPDATING-Z4H}/olets/zsh-job-queue $Z4H_PACKAGE_DIR/'
+  'rm -rf $Z4H_PACKAGE_DIR/zsh-job-queue; ln -s ${Z4H_UPDATING-$Z4H}/olets/zsh-job-queue $Z4H_PACKAGE_DIR/'
 
 # After 'z4h init':
 z4h load olets/zsh-abbr

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -41,7 +41,7 @@ Another option that doesn't use git is to install the required dependency manual
 z4h install olets/zsh-job-queue || return # Dependency for olets/zsh-abbr.
 z4h install olets/zsh-abbr || return
 zstyle :z4h:olets/zsh-abbr postinstall \
-  'rm -rf $Z4H_PACKAGE_DIR/zsh-job-queue; ln -s $Z4H/olets/zsh-job-queue $Z4H_PACKAGE_DIR/'
+  'rm -rf $Z4H_PACKAGE_DIR/zsh-job-queue; ln -s ${Z4H_UPDATING-Z4H}/olets/zsh-job-queue $Z4H_PACKAGE_DIR/'
 
 # After 'z4h init':
 z4h load olets/zsh-abbr

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -40,7 +40,8 @@ Another option that doesn't use git is to install the required dependency manual
 # Before 'z4h init':
 z4h install olets/zsh-job-queue || return # Dependency for olets/zsh-abbr.
 z4h install olets/zsh-abbr || return
-zstyle :z4h:olets/zsh-abbr postinstall 'ln -fFs $Z4H/olets/zsh-job-queue $Z4H_PACKAGE_DIR/'
+zstyle :z4h:olets/zsh-abbr postinstall \
+  'rm -rf $Z4H_PACKAGE_DIR/zsh-job-queue; ln -s $Z4H/olets/zsh-job-queue $Z4H_PACKAGE_DIR/'
 
 # After 'z4h init':
 z4h load olets/zsh-abbr

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -32,6 +32,20 @@ zstyle :z4h:olets/zsh-abbr postinstall z4h-postinstall:replace-with-github-clone
 z4h load olets/zsh-abbr
 ```
 
+Another option that doesn't use git is to install the required dependency manually:
+
+```shell
+# .zshrc
+
+# Before 'z4h init':
+z4h install olets/zsh-job-queue || return # Dependency for olets/zsh-abbr.
+z4h install olets/zsh-abbr || return
+zstyle ':z4h:olets/zsh-abbr' postinstall 'ln -fFs $Z4H/olets/zsh-job-queue $Z4H_PACKAGE_DIR/'
+
+# After 'z4h init':
+z4h load olets/zsh-abbr
+```
+
 Otherwise, read [Installation&nbsp;>&nbsp;Manual](./installation.md#manual)'s note on GitHub's REST API. You'll indentify the latest release's associated tag, use that to determine the archive URL to download, and then extract the archive into `Z4H_PACKAGE_DIR`. The following pattern is recommended. (Contributions of a clean solution are welcome.)
 
 ```shell

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -40,7 +40,7 @@ Another option that doesn't use git is to install the required dependency manual
 # Before 'z4h init':
 z4h install olets/zsh-job-queue || return # Dependency for olets/zsh-abbr.
 z4h install olets/zsh-abbr || return
-zstyle ':z4h:olets/zsh-abbr' postinstall 'ln -fFs $Z4H/olets/zsh-job-queue $Z4H_PACKAGE_DIR/'
+zstyle :z4h:olets/zsh-abbr postinstall 'ln -fFs $Z4H/olets/zsh-job-queue $Z4H_PACKAGE_DIR/'
 
 # After 'z4h init':
 z4h load olets/zsh-abbr


### PR DESCRIPTION
Instead of downloading an unnecessary archive and discarding it entirely, this method simply installs the `zsh-job-queue` dependency separately, then links it to the correct location via a post-install hook.

This method assumes that the linked submodule commit in `zsh-abbr` will remain "synchronized" with `zsh-job-queue` repo's main branch. This seems like a reasonable compromise to me, since:
- new major versions for `zsh-job-queue` are incorporated very quickly downstream in `zsh-abbr` ([a whole 10 minutes](https://github.com/olets/zsh-abbr/commit/932e74b56e624827dc6eb297572189d81ee24c27) for [`zsh-job-queue` 3.0.0](https://github.com/olets/zsh-job-queue/commit/9e9908225935f2f60d7d41947eb04f3af3c749fe)!)
- `zsh4humans` only checks for updates periodically ([28 days by default](https://github.com/romkatv/zsh4humans/blob/c0c29f999635f58e2b1bdb442e633c01a1b9ecc2/.zshrc#L11)), so there should only a very small window where "desyncs" _could_ occur (i.e. when the linked submodule commit and the main branch differ)

I'm more than happy to make any changes to this pull request. Thank you for all the work you've put into this project!