### PR TITLE
fix(integrations): zstyle uses placeholder instead of package name

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -51,7 +51,7 @@ z4h-postinstall:reinstall() {
 }
 
 z4h install olets/zsh-abbr || return
-zstyle :z4h:<package> postinstall z4h-postinstall:reinstall
+zstyle :z4h:olets/zsh-abbr postinstall z4h-postinstall:reinstall
 z4h load olets/zsh-abbr
 ```
 


### PR DESCRIPTION
Cherry-picked the fixed line from #5, [reference](https://github.com/olets/zsh-abbr-v6-docs/pull/5#discussion_r3434181838).